### PR TITLE
Add executor_type support to CLI config loading

### DIFF
--- a/src/jernerics/_cli_helpers.py
+++ b/src/jernerics/_cli_helpers.py
@@ -147,7 +147,7 @@ def find_pyproject_dir(start_dir: str | Path | None = None) -> Path | None:
 
 def load_config(
     config_file: str,
-) -> tuple[dict[str, Any], list[dict[str, Any]], int | None]:
+) -> tuple[dict[str, Any], list[dict[str, Any]], int | None, str | None]:
     config_path = Path(config_file)
     if not config_path.exists():
         raise FileNotFoundError(f"Config file not found: {config_file}")
@@ -166,8 +166,9 @@ def load_config(
 
     slurm = module_ns.get("slurm", {})
     max_workers = module_ns.get("max_workers", None)
+    executor_type = module_ns.get("executor_type", None)
 
-    return slurm, configs, max_workers
+    return slurm, configs, max_workers, executor_type
 
 
 def get_script_path(script_name: str, script_module: str = "jernerics.scripts") -> str:

--- a/src/jernerics/cli.py
+++ b/src/jernerics/cli.py
@@ -72,7 +72,7 @@ def run_local(
         raise SystemExit(ExitCode.CONFIG_ERROR)
 
     try:
-        _, configs, _ = load_config(config_path)
+        _, configs, _, _ = load_config(config_path)
     except FileNotFoundError as e:
         print(f"Error: {e}")
         raise SystemExit(ExitCode.CONFIG_ERROR)
@@ -183,7 +183,7 @@ def run_slurm(
         raise SystemExit(ExitCode.CONFIG_ERROR)
 
     try:
-        config_slurm, configs, _ = load_config(str(config_path))
+        config_slurm, configs, _, _ = load_config(str(config_path))
     except NoConfigsFound as e:
         print(f"Error: {e}")
         raise SystemExit(ExitCode.CONFIG_ERROR)
@@ -310,11 +310,13 @@ def run_slurm(
     script_lines.append("from jernerics._cli_helpers import load_config")
     script_lines.append("")
     script_lines.append("dag = DAG(dag_file)")
-    script_lines.append("slurm_opts, configs, max_workers = load_config(config_file)")
+    script_lines.append(
+        "slurm_opts, configs, max_workers, executor_type = load_config(config_file)"
+    )
     script_lines.append("config = configs[config_index]")
     script_lines.append("")
     script_lines.append(
-        "results = dag.run(config, config_index=config_index, config_path=config_file, max_workers=max_workers)"
+        "results = dag.run(config, config_index=config_index, config_path=config_file, max_workers=max_workers, executor_type=executor_type or 'thread')"
     )
     script_lines.append("")
     script_lines.append(
@@ -409,10 +411,10 @@ from jernerics.dag import DAG
 from jernerics._cli_helpers import load_config
 
 dag = DAG(dag_file)
-slurm_opts, configs, max_workers = load_config(config_file)
+slurm_opts, configs, max_workers, executor_type = load_config(config_file)
 config = configs[config_index]
 
-results = dag.run(config, config_index=config_index, config_path=config_file, container_path=container_path, max_workers=max_workers)
+results = dag.run(config, config_index=config_index, config_path=config_file, container_path=container_path, max_workers=max_workers, executor_type=executor_type or 'thread')
 
 failed = [name for name, result in results.items() if isinstance(result, Exception)]
 if failed:

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -24,13 +24,14 @@ configs = [
         config_file = tmp_path / "config.py"
         config_file.write_text(config_content)
 
-        slurm, configs, max_workers = load_config(str(config_file))
+        slurm, configs, max_workers, executor_type = load_config(str(config_file))
 
         assert slurm == {}
         assert len(configs) == 2
         assert configs[0]["seed"] == 1
         assert configs[1]["lr"] == 0.01
         assert max_workers is None
+        assert executor_type is None
 
     def test_load_config_with_slurm(self, tmp_path):
         config_content = """
@@ -45,7 +46,7 @@ configs = [{"seed": 1}]
         config_file = tmp_path / "config.py"
         config_file.write_text(config_content)
 
-        slurm, configs, _max_workers = load_config(str(config_file))
+        slurm, configs, _max_workers, _executor_type = load_config(str(config_file))
 
         assert slurm["time"] == "1:00:00"
         assert slurm["mem"] == "4G"
@@ -59,7 +60,7 @@ configs = [{"x": 1}]
         config_file = tmp_path / "config.py"
         config_file.write_text(config_content)
 
-        slurm, configs, _max_workers = load_config(str(config_file))
+        slurm, configs, _max_workers, _executor_type = load_config(str(config_file))
 
         assert slurm == {}
         assert configs == [{"x": 1}]
@@ -106,7 +107,7 @@ configs = [{"env": os.environ.get("TEST_VAR", "default")}]
         config_file = tmp_path / "config.py"
         config_file.write_text(config_content)
 
-        _slurm, configs, _max_workers = load_config(str(config_file))
+        _slurm, configs, _max_workers, _executor_type = load_config(str(config_file))
 
         assert "env" in configs[0]
 
@@ -120,7 +121,7 @@ configs = [{"seed": s, "lr": l} for s in seeds for l in lrs]
         config_file = tmp_path / "config.py"
         config_file.write_text(config_content)
 
-        _slurm, configs, _max_workers = load_config(str(config_file))
+        _slurm, configs, _max_workers, _executor_type = load_config(str(config_file))
 
         assert len(configs) == 6
         assert configs[0] == {"seed": 1, "lr": 0.001}
@@ -133,7 +134,7 @@ configs = [{"single": "config"}]
         config_file = tmp_path / "config.py"
         config_file.write_text(config_content)
 
-        _slurm, configs, _max_workers = load_config(str(config_file))
+        _slurm, configs, _max_workers, _executor_type = load_config(str(config_file))
 
         assert len(configs) == 1
         assert configs[0] == {"single": "config"}
@@ -150,7 +151,7 @@ configs = [
         config_file = tmp_path / "config.py"
         config_file.write_text(config_content)
 
-        _slurm, configs, _max_workers = load_config(str(config_file))
+        _slurm, configs, _max_workers, _executor_type = load_config(str(config_file))
 
         assert configs[0]["model"]["layers"] == 3
         assert configs[0]["training"]["epochs"] == 100
@@ -159,7 +160,7 @@ configs = [
         config_file = tmp_path / "config with spaces.py"
         config_file.write_text('configs = [{"x": 1}]')
 
-        _slurm, configs, _max_workers = load_config(str(config_file))
+        _slurm, configs, _max_workers, _executor_type = load_config(str(config_file))
 
         assert configs == [{"x": 1}]
 
@@ -172,7 +173,21 @@ configs = [{"seed": 1}]
         config_file = tmp_path / "config.py"
         config_file.write_text(config_content)
 
-        _slurm, configs, max_workers = load_config(str(config_file))
+        _slurm, configs, max_workers, _executor_type = load_config(str(config_file))
 
         assert max_workers == 4
+        assert len(configs) == 1
+
+    def test_load_config_with_executor_type(self, tmp_path):
+        config_content = """
+executor_type = "serial"
+
+configs = [{"seed": 1}]
+"""
+        config_file = tmp_path / "config.py"
+        config_file.write_text(config_content)
+
+        _slurm, configs, _max_workers, executor_type = load_config(str(config_file))
+
+        assert executor_type == "serial"
         assert len(configs) == 1


### PR DESCRIPTION
## Summary
- Updates `load_config()` to extract `executor_type` from config files
- Passes `executor_type` to `dag.run()` in CLI commands (`run local` and `run slurm`)
- Adds tests for the new `executor_type` parameter

Fixes #1