### PR TITLE
fix: include README.md in python.def template

### DIFF
--- a/src/jernerics/templates/python.def
+++ b/src/jernerics/templates/python.def
@@ -4,6 +4,7 @@ From: python:3.12-slim
 %files
     pyproject.toml /build/project/pyproject.toml
     uv.lock /build/project/uv.lock
+    README.md /build/project/README.md
     src/ /build/project/src/
 
 %post

--- a/tests/unit/container/test_templates.py
+++ b/tests/unit/container/test_templates.py
@@ -13,6 +13,10 @@ class TestTemplates:
         assert "Bootstrap: docker" in template
         assert "python:3.12" in template
 
+    def test_python_template_includes_readme(self):
+        template = get_template("python")
+        assert "README.md" in template
+
     def test_get_invalid_template(self):
         with pytest.raises(ValueError, match="not found"):
             get_template("nonexistent")


### PR DESCRIPTION
## Summary
- Adds `README.md` to the `%files` section in `python.def` template
- Hatchling requires README.md during `uv sync` if pyproject.toml references it
- Adds test to verify README.md is included in template

## Test plan
- [x] `pytest tests/unit/container/test_templates.py` passes
- [x] All linting/type checks pass

Fixes #5