### PR TITLE
fix: preserve relative paths for DAG and config files in SLURM scripts

### DIFF
--- a/src/jernerics/cli.py
+++ b/src/jernerics/cli.py
@@ -226,21 +226,25 @@ def run_slurm(
     else:
         array_spec = f"1-{num_configs}"
 
-    dag_basename = dag_path.name
-    config_basename = config_path.name
+    dag_relpath = dag_path.relative_to(project_dir)
+    config_relpath = config_path.relative_to(project_dir)
 
-    _SAFE_BASENAME = re.compile(r"^[a-zA-Z0-9_.\-]+$")
+    _SAFE_RELPATH = re.compile(r"^[a-zA-Z0-9_./\-]+$")
 
-    def validate_basename(name: str, desc: str) -> str:
-        if not _SAFE_BASENAME.match(name):
+    def validate_relpath(path: str, desc: str) -> str:
+        if not _SAFE_RELPATH.match(path):
             raise SystemExit(
-                f"Error: {desc} filename '{name}' contains unsafe characters. "
-                "Only alphanumeric, underscore, hyphen, and period allowed."
+                f"Error: {desc} path '{path}' contains unsafe characters. "
+                "Only alphanumeric, underscore, hyphen, period, and slash allowed."
             )
-        return name
+        if ".." in path:
+            raise SystemExit(
+                f"Error: {desc} path '{path}' must not contain '..' (path traversal)."
+            )
+        return path
 
-    dag_basename = validate_basename(dag_basename, "DAG file")
-    config_basename = validate_basename(config_basename, "Config file")
+    dag_relpath = validate_relpath(str(dag_relpath), "DAG file")
+    config_relpath = validate_relpath(str(config_relpath), "Config file")
 
     output_pattern = str(slurm_opts.get("output", "slurm_%j.out"))
     error_pattern = str(slurm_opts.get("error", "slurm_%j.err"))
@@ -287,8 +291,8 @@ def run_slurm(
         output_dir = str(Path(output_path).parent)
     script_lines.append(f"mkdir -p {safe_shell_path(output_dir)}")
     script_lines.append("CONFIG_INDEX=$((SLURM_ARRAY_TASK_ID - 1))")
-    script_lines.append(f"export JERNERICS_DAG_FILE=/work/{dag_basename}")
-    script_lines.append(f"export JERNERICS_CONFIG_FILE=/work/{config_basename}")
+    script_lines.append(f"export JERNERICS_DAG_FILE=/work/{dag_relpath}")
+    script_lines.append(f"export JERNERICS_CONFIG_FILE=/work/{config_relpath}")
     script_lines.append("export JERNERICS_CONFIG_INDEX=${CONFIG_INDEX}")
     script_lines.append(f"cd {safe_shell_path(remote_dir)}")
     script_lines.append("REMOTE_DIR=$(cd . && pwd)")

--- a/tests/integration/test_cli_run.py
+++ b/tests/integration/test_cli_run.py
@@ -362,3 +362,175 @@ class TestRunSlurmScriptGeneration:
         )
         assert result.returncode == 0
         assert "cd ~/experiments/test-project" in result.stdout
+
+
+class TestRunSlurmSubdirectoryPaths:
+    def test_config_in_subdirectory_preserves_relative_path(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        (project_dir / "pyproject.toml").write_text(
+            """
+[project]
+name = "test-project"
+
+[tool.jernerics.hpc]
+host = "user@hpc.example.edu"
+remote_dir = "~/experiments/{project_name}"
+"""
+        )
+
+        configs_dir = project_dir / "configs"
+        configs_dir.mkdir()
+
+        (project_dir / "dag.py").write_text(
+            "from jernerics.dag import DAG\ndag = DAG()"
+        )
+        (configs_dir / "experiment.py").write_text(
+            "configs = [{'seed': 1}]\nslurm = {}"
+        )
+        (project_dir / "uv.lock").write_text("version = 1\n")
+
+        result = subprocess.run(
+            [
+                "jernerics",
+                "run",
+                "slurm",
+                "dag.py",
+                "configs/experiment.py",
+                "--dry-run",
+            ],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "JERNERICS_CONFIG_FILE=/work/configs/experiment.py" in result.stdout
+
+    def test_dag_in_subdirectory_preserves_relative_path(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        (project_dir / "pyproject.toml").write_text(
+            """
+[project]
+name = "test-project"
+
+[tool.jernerics.hpc]
+host = "user@hpc.example.edu"
+remote_dir = "~/experiments/{project_name}"
+"""
+        )
+
+        experiments_dir = project_dir / "experiments"
+        experiments_dir.mkdir()
+
+        (experiments_dir / "pipeline.py").write_text(
+            "from jernerics.dag import DAG\ndag = DAG()"
+        )
+        (project_dir / "config.py").write_text("configs = [{'seed': 1}]\nslurm = {}")
+        (project_dir / "uv.lock").write_text("version = 1\n")
+
+        result = subprocess.run(
+            [
+                "jernerics",
+                "run",
+                "slurm",
+                "experiments/pipeline.py",
+                "config.py",
+                "--dry-run",
+            ],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "JERNERICS_DAG_FILE=/work/experiments/pipeline.py" in result.stdout
+
+    def test_both_files_in_subdirectories(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        (project_dir / "pyproject.toml").write_text(
+            """
+[project]
+name = "test-project"
+
+[tool.jernerics.hpc]
+host = "user@hpc.example.edu"
+remote_dir = "~/experiments/{project_name}"
+"""
+        )
+
+        experiments_dir = project_dir / "experiments"
+        experiments_dir.mkdir()
+        configs_dir = experiments_dir / "configs"
+        configs_dir.mkdir()
+
+        (experiments_dir / "pipeline.py").write_text(
+            "from jernerics.dag import DAG\ndag = DAG()"
+        )
+        (configs_dir / "experiment.py").write_text(
+            "configs = [{'seed': 1}]\nslurm = {}"
+        )
+        (project_dir / "uv.lock").write_text("version = 1\n")
+
+        result = subprocess.run(
+            [
+                "jernerics",
+                "run",
+                "slurm",
+                "experiments/pipeline.py",
+                "experiments/configs/experiment.py",
+                "--dry-run",
+            ],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "JERNERICS_DAG_FILE=/work/experiments/pipeline.py" in result.stdout
+        assert (
+            "JERNERICS_CONFIG_FILE=/work/experiments/configs/experiment.py"
+            in result.stdout
+        )
+
+    def test_rejects_path_traversal_in_dag_path(self, tmp_path):
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+
+        (project_dir / "pyproject.toml").write_text(
+            """
+[project]
+name = "test-project"
+
+[tool.jernerics.hpc]
+host = "user@hpc.example.edu"
+remote_dir = "~/experiments/{project_name}"
+"""
+        )
+
+        (project_dir / "dag.py").write_text(
+            "from jernerics.dag import DAG\ndag = DAG()"
+        )
+        (project_dir / "config.py").write_text("configs = [{'seed': 1}]\nslurm = {}")
+        (project_dir / "uv.lock").write_text("version = 1\n")
+
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        (outside_dir / "malicious.py").write_text("print('bad')")
+
+        result = subprocess.run(
+            [
+                "jernerics",
+                "run",
+                "slurm",
+                "../outside/malicious.py",
+                "config.py",
+                "--dry-run",
+            ],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0


### PR DESCRIPTION
## Summary
- Replace basename extraction with relative path from project root for DAG and config files
- Update validation regex to allow path separators (`/`)
- Add explicit check for path traversal (`..`) attempts
- Add comprehensive tests for subdirectory handling and path traversal rejection

## Problem
When config files are in subdirectories (e.g., `configs/pysr_quick_test.py`), the SLURM script only used the basename, causing `FileNotFoundError`:
```bash
jernerics run slurm experiments/pysr_experiment.py experiments/configs/pysr_quick_test.py
# Before: JERNERICS_CONFIG_FILE=/work/pysr_quick_test.py
# After:  JERNERICS_CONFIG_FILE=/work/configs/pysr_quick_test.py
```

## Test plan
- [x] `pytest tests/integration/test_cli_run.py` - all 23 tests pass
- [x] All linting/type checks pass

Fixes #6