### PR TITLE
fix: File syncer respects .gitignore for project structure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "cloudpickle>=3.0.0",
     "numpy>=2.3.3",
     "tomli-w>=1.0.0",
+    "pathspec>=0.12.1",
 ]
 
 [project.scripts]

--- a/src/jernerics/cli.py
+++ b/src/jernerics/cli.py
@@ -353,19 +353,7 @@ def run_slurm(
     slurm = SlurmJobManager(ssh)
 
     print(f"[1/3] Syncing project to {hpc_config.host}:{remote_dir}...")
-
-    sync_dirs = list(FileSyncer.DEFAULT_DIRS)
-    sync_files = list(FileSyncer.DEFAULT_FILES)
-
-    dag_parent = str(Path(dag_relpath).parent)
-    if dag_parent != "." and dag_parent not in sync_dirs:
-        sync_dirs.append(dag_parent)
-
-    config_parent = str(Path(config_relpath).parent)
-    if config_parent != "." and config_parent not in sync_dirs:
-        sync_dirs.append(config_parent)
-
-    syncer.sync_project(project_dir, files=sync_files, dirs=sync_dirs)
+    syncer.sync_project(project_dir)
 
     print("[2/3] Ensuring log directory exists...")
     ssh.mkdir(f"{remote_dir}/.jernerics/logs")

--- a/src/jernerics/hpc/sync.py
+++ b/src/jernerics/hpc/sync.py
@@ -3,17 +3,64 @@ import tarfile
 import tempfile
 from pathlib import Path
 
+import pathspec
+
 from jernerics.hpc.ssh import _quote_path
 
 DEFAULT_SCP_TIMEOUT = 300
 
+DEFAULT_EXCLUDES = [
+    ".git/",
+    ".jernerics/",
+    "__pycache__/",
+    "*.pyc",
+    "*.sif",
+    ".cache/",
+    "results/",
+    ".venv/",
+    "venv/",
+    "*.egg-info/",
+    ".eggs/",
+    "build/",
+    "dist/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+]
 
-def _safe_tar_filter(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo | None:
-    if tarinfo.islnk() or tarinfo.issym():
+
+def _load_gitignore(project_path: Path) -> pathspec.PathSpec | None:
+    gitignore_path = project_path / ".gitignore"
+    if not gitignore_path.exists():
         return None
-    if tarinfo.name.startswith("/") or ".." in tarinfo.name:
-        return None
-    return tarinfo
+    patterns = gitignore_path.read_text().splitlines()
+    return pathspec.PathSpec.from_lines("gitignore", patterns)
+
+
+def _should_include(
+    rel_path: str,
+    gitignore_spec: pathspec.PathSpec | None,
+    default_spec: pathspec.PathSpec,
+) -> bool:
+    if gitignore_spec and gitignore_spec.match_file(rel_path):
+        return False
+    if default_spec.match_file(rel_path):
+        return False
+    return True
+
+
+def _collect_files(
+    project_path: Path,
+    gitignore_spec: pathspec.PathSpec | None,
+    default_spec: pathspec.PathSpec,
+) -> list[Path]:
+    files = []
+    for item in project_path.rglob("*"):
+        if not item.is_file():
+            continue
+        rel_path = item.relative_to(project_path).as_posix()
+        if _should_include(rel_path, gitignore_spec, default_spec):
+            files.append(item)
+    return files
 
 
 class FileSyncer:
@@ -21,56 +68,34 @@ class FileSyncer:
         self.ssh = ssh_client
         self.remote_dir = remote_dir.rstrip("/")
 
-    DEFAULT_FILES = [
-        "pyproject.toml",
-        "uv.lock",
-        "container.def",
-        "dag.py",
-        "config.py",
-    ]
-    DEFAULT_DIRS = ["src"]
-
     def sync_project(
         self,
         project_dir: str | Path,
-        exclude_patterns: list[str] | None = None,
         dry_run: bool = False,
-        files: list[str] | None = None,
-        dirs: list[str] | None = None,
     ) -> bool:
         project_path = Path(project_dir)
 
-        if exclude_patterns is None:
-            exclude_patterns = [
-                "*.pyc",
-                "__pycache__",
-                "*.sif",
-                ".git",
-                ".cache",
-                "results",
-                ".jernerics",
-            ]
+        gitignore_spec = _load_gitignore(project_path)
+        default_spec = pathspec.PathSpec.from_lines("gitignore", DEFAULT_EXCLUDES)
+
+        files_to_sync = _collect_files(project_path, gitignore_spec, default_spec)
+
+        if not files_to_sync:
+            return True
 
         self.ssh.mkdir(self.remote_dir)
-
-        files_to_sync = files if files is not None else self.DEFAULT_FILES
-        dirs_to_sync = dirs if dirs is not None else self.DEFAULT_DIRS
-
-        existing_files = [f for f in files_to_sync if (project_path / f).exists()]
-        existing_dirs = [d for d in dirs_to_sync if (project_path / d).is_dir()]
 
         with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
             tmp_path = tmp.name
 
         try:
             with tarfile.open(tmp_path, "w:gz") as tar:
-                for f in existing_files:
-                    tar.add(project_path / f, arcname=f, filter=_safe_tar_filter)
-                for d in existing_dirs:
-                    tar.add(project_path / d, arcname=d, filter=_safe_tar_filter)
+                for file_path in files_to_sync:
+                    arcname = file_path.relative_to(project_path)
+                    tar.add(file_path, arcname=str(arcname))
 
             if dry_run:
-                print(f"Would sync: {existing_files + existing_dirs}")
+                print(f"Would sync {len(files_to_sync)} files")
                 return True
 
             remote_tar_path = f"{self.remote_dir}/sync.tar.gz"

--- a/tests/unit/hpc/test_sync.py
+++ b/tests/unit/hpc/test_sync.py
@@ -139,32 +139,36 @@ class TestFileSyncer:
             assert args[0][0] == "scp"
             assert "user@host.example.edu:~/projects/test/results.json" in args[0][1]
 
-    def test_sync_project_default_files_constant(self):
-        assert FileSyncer.DEFAULT_FILES == [
-            "pyproject.toml",
-            "uv.lock",
-            "container.def",
-            "dag.py",
-            "config.py",
-        ]
-        assert FileSyncer.DEFAULT_DIRS == ["src"]
-
-    def test_sync_project_accepts_custom_files_dirs(self, tmp_path):
+    def test_sync_project_respects_gitignore(self, tmp_path):
         mock_ssh = MagicMock()
         mock_ssh.host = "user@host.example.edu"
         syncer = FileSyncer(mock_ssh, "~/projects/test")
 
-        (tmp_path / "custom.py").write_text("content")
-        (tmp_path / "mydir").mkdir()
-        (tmp_path / "mydir" / "__init__.py").write_text("")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("content")
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "large.csv").write_text("data")
+        (tmp_path / ".gitignore").write_text("data/\n*.csv\n")
 
-        with (
-            patch("jernerics.hpc.sync.subprocess.run") as mock_run,
-        ):
+        with patch("jernerics.hpc.sync.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
+            result = syncer.sync_project(tmp_path, dry_run=True)
 
-            result = syncer.sync_project(
-                tmp_path, files=["custom.py"], dirs=["mydir"], dry_run=True
-            )
+            assert result is True
+
+    def test_sync_project_includes_all_by_default(self, tmp_path):
+        mock_ssh = MagicMock()
+        mock_ssh.host = "user@host.example.edu"
+        syncer = FileSyncer(mock_ssh, "~/projects/test")
+
+        (tmp_path / "experiments").mkdir()
+        (tmp_path / "experiments" / "dag.py").write_text("dag")
+        (tmp_path / "experiments" / "config.py").write_text("config")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("main")
+
+        with patch("jernerics.hpc.sync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = syncer.sync_project(tmp_path, dry_run=True)
 
             assert result is True

--- a/uv.lock
+++ b/uv.lock
@@ -170,6 +170,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },
     { name = "numpy" },
+    { name = "pathspec" },
     { name = "pyyaml" },
     { name = "tomli-w" },
     { name = "typer" },
@@ -190,6 +191,7 @@ dev = [
 requires-dist = [
     { name = "cloudpickle", specifier = ">=3.0.0" },
     { name = "numpy", specifier = ">=2.3.3" },
+    { name = "pathspec", specifier = ">=0.12.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "typer", specifier = ">=0.19.1" },
@@ -306,6 +308,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Sync entire project while respecting `.gitignore` patterns
- Add `pathspec` dependency for gitignore parsing
- Remove fixed file/dir lists in favor of git-aware approach

## Rationale
Following ML best practices: large datasets should be managed via DVC/external storage, not synced with code. The syncer now respects `.gitignore` so anything git would track gets synced.

Fixes #10