### PR TITLE
Improve error observability in logs

### DIFF
--- a/src/jernerics/cli.py
+++ b/src/jernerics/cli.py
@@ -248,8 +248,8 @@ def run_slurm(
     dag_relpath = validate_relpath(str(dag_relpath), "DAG file")
     config_relpath = validate_relpath(str(config_relpath), "Config file")
 
-    output_pattern = str(slurm_opts.get("output", "slurm_%j.out"))
-    error_pattern = str(slurm_opts.get("error", "slurm_%j.err"))
+    output_pattern = str(slurm_opts.get("output", "logs/slurm_%j.out"))
+    error_pattern = str(slurm_opts.get("error", "logs/slurm_%j.err"))
 
     def expand_path(p: str) -> str:
         if p.startswith("~"):
@@ -305,6 +305,7 @@ def run_slurm(
     script_lines.append("import os")
     script_lines.append("import sys")
     script_lines.append("import pathlib")
+    script_lines.append("import traceback")
     script_lines.append("")
     script_lines.append('dag_file = os.environ["JERNERICS_DAG_FILE"]')
     script_lines.append('config_file = os.environ["JERNERICS_CONFIG_FILE"]')
@@ -326,12 +327,16 @@ def run_slurm(
     )
     script_lines.append("")
     script_lines.append(
-        "failed = [name for name, result in results.items() if isinstance(result, Exception)]"
+        "failed = [(name, result) for name, result in results.items() if isinstance(result, Exception)]"
     )
     script_lines.append("if failed:")
+    script_lines.append('    print("DAG failed with errors:\\n")')
+    script_lines.append("    for name, exc in failed:")
+    script_lines.append('        print(f"  [{name}] {type(exc).__name__}: {exc}")')
     script_lines.append(
-        '    print("DAG failed. Tasks with errors:", ", ".join(failed))'
+        "        traceback.print_exception(type(exc), exc, exc.__traceback__)"
     )
+    script_lines.append("        print()")
     script_lines.append("    sys.exit(1)")
     script_lines.append("else:")
     script_lines.append('    print("DAG completed")')
@@ -373,8 +378,8 @@ def run_slurm(
 
         job_meta = {
             "job_id": job_id,
-            "output_pattern": str(slurm_opts.get("output", "slurm_%j.out")),
-            "error_pattern": str(slurm_opts.get("error", "slurm_%j.err")),
+            "output_pattern": str(slurm_opts.get("output", "logs/slurm_%j.out")),
+            "error_pattern": str(slurm_opts.get("error", "logs/slurm_%j.err")),
             "remote_dir": remote_dir,
             "num_configs": num_configs,
         }
@@ -568,13 +573,13 @@ def logs(
     meta_file = project_dir / ".jernerics" / "jobs" / f"{job_id}.json"
     if meta_file.exists():
         meta = json.loads(meta_file.read_text())
-        output_pattern = meta.get("output_pattern", "slurm_%j.out")
-        error_pattern = meta.get("error_pattern", "slurm_%j.err")
+        output_pattern = meta.get("output_pattern", "logs/slurm_%j.out")
+        error_pattern = meta.get("error_pattern", "logs/slurm_%j.err")
         meta_remote_dir = meta.get("remote_dir", remote_dir)
         num_configs = meta.get("num_configs", 1)
     else:
-        output_pattern = "slurm_%j.out"
-        error_pattern = "slurm_%j.err"
+        output_pattern = "logs/slurm_%j.out"
+        error_pattern = "logs/slurm_%j.err"
         meta_remote_dir = remote_dir
         num_configs = 1
 

--- a/src/jernerics/container/builder.py
+++ b/src/jernerics/container/builder.py
@@ -1,3 +1,4 @@
+import json
 import re
 import subprocess
 from pathlib import Path
@@ -122,7 +123,7 @@ echo "=== Build completed at $(date) ==="
         self.ensure_container_def()
 
         remote_dir = self._get_remote_dir()
-        slurm_output_dir = self.ssh.expand_tilde(remote_dir)
+        slurm_output_dir = f"{self.ssh.expand_tilde(remote_dir)}/logs"
 
         if dry_run:
             print("=== DRY RUN ===")
@@ -134,13 +135,16 @@ echo "=== Build completed at $(date) ==="
             print(self._generate_build_script(slurm_output_dir))
             return None
 
-        print(f"[1/3] Syncing project to {self.config.host}:{remote_dir}")
+        print(f"[1/4] Syncing project to {self.config.host}:{remote_dir}")
         self.syncer.sync_project(self.project_dir)
+
+        print("[2/4] Creating logs directory...")
+        self.ssh.mkdir(f"{remote_dir}/logs")
 
         build_script = self._generate_build_script(slurm_output_dir)
         remote_script_path = f"{remote_dir}/build_container.sh"
 
-        print("[2/3] Uploading build script...")
+        print("[3/4] Uploading build script...")
         quoted_script_path = _quote_path(remote_script_path)
         result = subprocess.run(
             ["ssh", self.config.host, f"cat > {quoted_script_path}"],
@@ -154,11 +158,23 @@ echo "=== Build completed at $(date) ==="
                 f"Failed to upload build script: {result.stderr or result.stdout}"
             )
 
-        print("[3/3] Submitting build job to SLURM...")
+        print("[4/4] Submitting build job to SLURM...")
         job_id = self.slurm.submit(remote_script_path)
+
+        job_meta = {
+            "job_id": job_id,
+            "job_type": "build",
+            "output_pattern": "logs/build_%j.out",
+            "error_pattern": "logs/build_%j.err",
+            "remote_dir": remote_dir,
+        }
+        meta_dir = self.project_dir / ".jernerics" / "jobs"
+        meta_dir.mkdir(parents=True, exist_ok=True)
+        meta_file = meta_dir / f"{job_id}.json"
+        meta_file.write_text(json.dumps(job_meta, indent=2))
+
         print(f"\nBuild job submitted: {job_id}")
         print("\nMonitor progress:")
-        quoted_log_path = _quote_path(f"{slurm_output_dir}/build_{job_id}.out")
-        print(f"  ssh {self.config.host} 'tail -f {quoted_log_path}'")
+        print(f"  jernerics logs {job_id} --follow")
 
         return job_id


### PR DESCRIPTION
## Summary
- Print full exception details (type and message) for failed tasks instead of just task names
- Move all SLURM logs to `logs/` directory (`logs/slurm_*.out`, `logs/build_*.out`)
- Save metadata for build jobs so `jernerics logs` works for them
- Update monitor command to use `jernerics logs` instead of direct SSH

Fixes #17