### PR TITLE
fix: add --fakeroot to all apptainer exec calls

### DIFF
--- a/src/jernerics/cli.py
+++ b/src/jernerics/cli.py
@@ -312,7 +312,7 @@ def run_slurm(
     bind_str = " \\\n    --bind ".join(bind_args)
 
     script_lines.append(
-        f"apptainer exec --contain --nv --pwd /work --bind {bind_str} container.sif \\"
+        f"apptainer exec --fakeroot --contain --nv --pwd /work --bind {bind_str} container.sif \\"
     )
     script_lines.append("    python -c \"$(cat <<'EOF'")
     script_lines.append("import os")

--- a/src/jernerics/hpc/#ssh.py#
+++ b/src/jernerics/hpc/#ssh.py#
@@ -1,0 +1,87 @@
+import shlex
+import subprocess
+
+
+def _validate_path(path: str) -> str:
+    if "\x00" in path:
+        raise ValueError("Path cannot contain null bytes")
+    return path
+
+
+def _quote_path(path: str) -> str:
+    """Quote a path for shell, preserving ~ expansion."""
+    if path.startswith("~"):
+        return "~" + shlex.quote(path[1:])
+    return shlex.quote(path)
+
+
+class SSHClient:
+    def __init__(self, host: str):
+        self.host = host
+
+    def run(
+        self,
+        command: str,
+        capture_output: bool = True,
+        check: bool = True,
+        timeout: int | None = None,
+        input: str | None = None,
+    ) -> subprocess.CompletedProcess:
+        ssh_args = ["ssh", "-o", "LogLevel=ERROR", self.host, command]
+        return subprocess.run(
+            ssh_args,
+            capture_output=capture_output,
+            text=True,
+            check=check
+,
+            timeout=timeout,
+            input=input,
+        )
+
+    def run_script(
+        self,
+        script: str,
+        check: bool = True,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["ssh", "-o", "LogLevel=ERROR", self.host, "bash -s"],
+            input=script,
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=timeout,
+        )
+
+    def mkdir(self, remote_path: str) -> subprocess.CompletedProcess:
+        _validate_path(remote_path)
+        return self.run(f"mkdir -p {_quote_path(remote_path)}")
+
+    def file_exists(self, remote_path: str) -> bool:
+        _validate_path(remote_path)
+        result = self.run(f"test -f {_quote_path(remote_path)}", check=False)
+        return result.returncode == 0
+
+    def getmtime(self, remote_path: str) -> float | None:
+        _validate_path(remote_path)
+        quoted = _quote_path(remote_path)
+        result = self.run(
+            f"stat -c %Y {quoted} 2>/dev/null || stat -f %m {quoted}", check=False
+        )
+        if result.returncode == 0:
+            return float(result.stdout.strip())
+        return None
+
+    def remove_file(self, remote_path: str) -> subprocess.CompletedProcess:
+        _validate_path(remote_path)
+        return self.run(f"rm -f {_quote_path(remote_path)}")
+
+    def get_home_dir(self) -> str:
+        result = self.run("echo $HOME", check=True)
+        return result.stdout.strip()
+
+    def expand_tilde(self, path: str) -> str:
+        if path.startswith("~"):
+            home = self.get_home_dir()
+            return home + path[1:]
+        return path

--- a/src/jernerics/scripts/run_dag_container.sh
+++ b/src/jernerics/scripts/run_dag_container.sh
@@ -22,6 +22,7 @@ export JERNERICS_RESULTS_DIR="/work/$RESULTS_DIR"
 export JERNERICS_CONFIG_INDEX="$CONFIG_INDEX"
 
 apptainer exec \
+    --fakeroot \
     --nv \
     --bind "$PROJECT_DIR:/work" \
     "$CONTAINER" \

--- a/src/jernerics/scripts/run_with_container.sh
+++ b/src/jernerics/scripts/run_with_container.sh
@@ -45,6 +45,7 @@ export JERNERICS_RESULTS_DIR="/work/$RESULTS_DIR"
 export JERNERICS_CONFIG_INDEX="$CONFIG_INDEX"
 
 apptainer exec \
+    --fakeroot \
     $GPU_FLAG \
     --bind "$PROJECT_DIR:/work" \
     "$SIF_PATH" \


### PR DESCRIPTION
## Summary
- Add `--fakeroot` flag to all three `apptainer exec` call sites that were missing it, fixing UID resolution failures on HPC nodes running rootless Apptainer

## Changes
- `src/jernerics/cli.py:315` — SLURM array job script
- `src/jernerics/scripts/run_dag_container.sh:24` — DAG container runner
- `src/jernerics/scripts/run_with_container.sh:47` — Generic container runner

Fixes #46