### PR TITLE
fix: remove max_parallel from DEFAULT_SLURM

### DIFF
--- a/src/jernerics/cli.py
+++ b/src/jernerics/cli.py
@@ -41,7 +41,6 @@ app.add_typer(container_app, name="container", help="Build and manage containers
 DEFAULT_SLURM = {
     "output": ".jernerics/logs/%A_%a.out",
     "error": ".jernerics/logs/%A_%a.err",
-    "max_parallel": 10,
 }
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -128,7 +128,7 @@ class TestDefaultSlurm:
 
         assert "output" in DEFAULT_SLURM
         assert "error" in DEFAULT_SLURM
-        assert "max_parallel" in DEFAULT_SLURM
+        assert "max_parallel" not in DEFAULT_SLURM
         assert "%A_%a" in DEFAULT_SLURM["output"]
 
 


### PR DESCRIPTION
## Summary
- Removes `"max_parallel": 10` from `DEFAULT_SLURM` in `cli.py` so that `HpcConfig.max_concurrent_jobs` (read from `[tool.jernerics.safety].max_concurrent_jobs` in `pyproject.toml`) is no longer overridden
- Updates test to assert `max_parallel` is **not** in `DEFAULT_SLURM`

Fixes #45