### PR TITLE
Support omitting SLURM time limit with time="none"

### DIFF
--- a/src/jernerics/_cli_helpers.py
+++ b/src/jernerics/_cli_helpers.py
@@ -38,12 +38,18 @@ class ConfigNotFound(Exception):
     pass
 
 
+def _normalize_time(value: str | None) -> str | None:
+    if isinstance(value, str) and value.lower() == "none":
+        return None
+    return value
+
+
 @dataclass
 class HpcConfig:
     host: str | None = None
     remote_dir: str = "~/experiments/{project_name}"
     partition: str = "priority"
-    time: str = "1:00:00"
+    time: str | None = "1:00:00"
     mem: str = "16G"
     cpus: int = 4
     max_concurrent_jobs: int = 10
@@ -91,7 +97,7 @@ def load_jernerics_config(
         remote_dir=hpc_config.get("remote_path")
         or hpc_config.get("remote_dir", "~/experiments/{project_name}"),
         partition=container_config.get("partition", "priority"),
-        time=container_config.get("time", "1:00:00"),
+        time=_normalize_time(container_config.get("time", "1:00:00")),
         mem=container_config.get("mem", "16G"),
         cpus=container_config.get("cpus", 4),
         max_concurrent_jobs=safety_config.get("max_concurrent_jobs", 10),

--- a/src/jernerics/cli.py
+++ b/src/jernerics/cli.py
@@ -18,6 +18,7 @@ from ._cli_helpers import (
     ConfigNotFound,
     ExitCode,
     NoConfigsFound,
+    _normalize_time,
     find_pyproject_dir,
     get_project_name,
     get_script_path,
@@ -216,9 +217,16 @@ def run_slurm(
         "partition": hpc_config.partition,
         "time": hpc_config.time,
         "mem": hpc_config.mem,
-        **config_slurm,
-        **cli_overrides,
+        **{
+            k: _normalize_time(v) if k == "time" else v for k, v in config_slurm.items()
+        },
+        **{
+            k: _normalize_time(v) if k == "time" else v
+            for k, v in cli_overrides.items()
+        },
     }
+
+    slurm_opts = {k: v for k, v in slurm_opts.items() if v is not None}
 
     max_parallel = slurm_opts.pop("max_parallel", hpc_config.max_concurrent_jobs)
     try:

--- a/src/jernerics/container/builder.py
+++ b/src/jernerics/container/builder.py
@@ -74,7 +74,7 @@ class ContainerBuilder:
         remote_dir = self._get_remote_dir()
         quoted_remote_dir = _quote_path(remote_dir)
         partition = _validate_slurm_value(self.config.partition, "partition")
-        time = _validate_slurm_value(self.config.time, "time")
+        time = _validate_slurm_value(self.config.time or "1:00:00", "time")
         mem = _validate_slurm_value(self.config.mem, "mem")
         cpus = _validate_slurm_value(str(self.config.cpus), "cpus")
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,6 +4,7 @@ from jernerics._cli_helpers import (
     ConfigNotFound,
     HpcConfig,
     ShellConfig,
+    _normalize_time,
     find_pyproject_dir,
     load_jernerics_config,
 )
@@ -268,3 +269,68 @@ remote_dir = "~/not_preferred/{project_name}"
 """)
         hpc_config, _, _ = load_jernerics_config(tmp_path)
         assert hpc_config.remote_dir == "~/preferred/{project_name}"
+
+
+class TestNormalizeTime:
+    def test_none_string_returns_none(self):
+        assert _normalize_time("none") is None
+
+    def test_none_string_case_insensitive(self):
+        assert _normalize_time("None") is None
+        assert _normalize_time("NONE") is None
+
+    def test_none_value_returns_none(self):
+        assert _normalize_time(None) is None
+
+    def test_time_string_passes_through(self):
+        assert _normalize_time("1:00:00") == "1:00:00"
+
+    def test_other_string_passes_through(self):
+        assert _normalize_time("72:00:00") == "72:00:00"
+
+
+class TestTimeNoneInConfig:
+    def test_toml_time_none(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+name = "test-project"
+
+[tool.jernerics.container]
+time = "none"
+""")
+        hpc_config, _, _ = load_jernerics_config(tmp_path)
+        assert hpc_config.time is None
+
+    def test_toml_time_none_case_insensitive(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+name = "test-project"
+
+[tool.jernerics.container]
+time = "None"
+""")
+        hpc_config, _, _ = load_jernerics_config(tmp_path)
+        assert hpc_config.time is None
+
+    def test_toml_time_normal(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+name = "test-project"
+
+[tool.jernerics.container]
+time = "2:00:00"
+""")
+        hpc_config, _, _ = load_jernerics_config(tmp_path)
+        assert hpc_config.time == "2:00:00"
+
+    def test_toml_time_default(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+name = "test-project"
+""")
+        hpc_config, _, _ = load_jernerics_config(tmp_path)
+        assert hpc_config.time == "1:00:00"


### PR DESCRIPTION
## Summary

- Allow `time = "none"` (case-insensitive) as a sentinel value in TOML config, Python config file `slurm` dict, and CLI `--set time=none`
- When set, the `#SBATCH --time=` line is omitted from generated SLURM scripts, letting SLURM fall back to the partition/system default
- Container build scripts always use a time limit (defaults to `"1:00:00"` when `time` is `None`)

Fixes #48